### PR TITLE
feat: Introduce Clone trait for Verdict enum

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -18,6 +18,7 @@ pub enum NfqueueError {
 }
 
 /// Decision on the packet
+#[derive(Clone)]
 pub enum Verdict {
     /// Discard the packet
     Drop,


### PR DESCRIPTION
I've been using nfqueue-rs for a little project and needed the `Verdict` enum to be cloneable. I've figured that this might be benefiting for others as well :) 