### PR TITLE
Enforce freeing Queue::qh by implementing Drop

### DIFF
--- a/examples/nfq-example.rs
+++ b/examples/nfq-example.rs
@@ -28,10 +28,10 @@ fn queue_callback(msg: &nfqueue::Message, state: &mut State) {
 }
 
 fn main() {
-    let mut q = nfqueue::Queue::new(State::new());
+    let mut q = nfqueue::Queue::new(State::new()).unwrap();
+
     println!("nfqueue example program: print packets metadata and accept packets");
 
-    q.open();
     q.unbind(libc::AF_INET); // ignore result, failure is not critical here
 
     let rc = q.bind(libc::AF_INET);
@@ -41,6 +41,4 @@ fn main() {
     q.set_mode(nfqueue::CopyMode::CopyPacket, 0xffff);
 
     q.run_loop();
-
-    q.close();
 }

--- a/examples/nfq-parse.rs
+++ b/examples/nfq-parse.rs
@@ -179,10 +179,9 @@ fn queue_callback(msg: &nfqueue::Message, state: &mut State) {
 }
 
 fn main() {
-    let mut q = nfqueue::Queue::new(State::new());
+    let mut q = nfqueue::Queue::new(State::new()).unwrap();
     println!("nfqueue example program: parse packet protocol layers and accept packet");
 
-    q.open();
     q.unbind(libc::AF_INET); // ignore result, failure is not critical here
 
     let rc = q.bind(libc::AF_INET);
@@ -192,6 +191,4 @@ fn main() {
     q.set_mode(nfqueue::CopyMode::CopyPacket, 0xffff);
 
     q.run_loop();
-
-    q.close();
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -131,10 +131,7 @@ extern "C" {
 
 impl Message {
     /// Create a `Messsage` from a valid NfqueueData pointer
-    ///
-    /// **This function should never be called directly**
-    #[doc(hidden)]
-    pub fn new(qqh: *const libc::c_void, nfad: NfqueueData) -> Message {
+    pub(crate) fn new(qqh: *const libc::c_void, nfad: *const libc::c_void) -> Message {
         let msg_hdr = unsafe { nfq_get_msg_packet_hdr(nfad) as *const NfMsgPacketHdr };
         assert!(!msg_hdr.is_null());
         let id = u32::from_be(unsafe { (*msg_hdr).packet_id });


### PR DESCRIPTION
It's possible to leak the handle by not calling `Queue::close`. `Queue::open` must have been called before it's valid to call any of its instance functions. It may as well be enforced through opening the handle during construction, and then we can be certain it can be deallocated in `Drop`.

A similar problem exists with `create_queue` and `destroy_queue`, but I'm trying to think of how to solve it in the right way to allow for multiple open queues and maybe supporting an async stream to read from all of them.