### PR TITLE
bind to nfq_set_queue_maxlen, remove nonexist nfq_set_queuelen

### DIFF
--- a/examples/nfq-example.rs
+++ b/examples/nfq-example.rs
@@ -39,6 +39,6 @@ fn main() {
 
     q.create_queue(0, queue_callback);
     q.set_mode(nfqueue::CopyMode::CopyPacket, 0xffff);
-
+    q.set_queue_maxlen(100);
     q.run_loop();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ extern "C" {
     fn nfq_handle_packet(qh: NfqueueHandle, buf: *mut libc::c_void, rc: libc::c_int)
         -> libc::c_int;
     fn nfq_set_mode(gh: NfqueueQueueHandle, mode: u8, range: u32) -> libc::c_int;
-    fn nfq_set_queuelen(gh: NfqueueQueueHandle, queuelen: u32) -> libc::c_int;
+    fn nfq_set_queue_maxlen(gh: NfqueueQueueHandle, queuelen: u32) -> libc::c_int;
 }
 
 /// Copy modes
@@ -257,10 +257,10 @@ impl<T: Send> Queue<T> {
     /// Sets the size of the queue in kernel. This fixes the maximum number of
     /// packets the kernel will store before internally before dropping upcoming
     /// packets
-    pub fn set_queuelen(&self, queuelen: u32) {
+    pub fn set_queue_maxlen(&self, queuelen: u32) {
         assert!(!self.qqh.is_null());
         unsafe {
-            nfq_set_queuelen(self.qqh, queuelen);
+            nfq_set_queue_maxlen(self.qqh, queuelen);
         }
     }
 


### PR DESCRIPTION
fixing what appears as being a typo in the ffi bindings along with a method name to enable compilation.
