### PR TITLE
Upgrade pnet dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ edition="2018"
 libc = "^0.2"
 
 [dev_dependencies]
-pnet = "0.25.0"
+pnet = "0.33.0"


### PR DESCRIPTION
This fixes #19 

I've tested the examples, and both seem to work on my machine with the updated `pnet` :

![image](https://user-images.githubusercontent.com/6680615/220686530-67614aad-2879-4fb6-a344-7bfcd1a744fc.png)
