### PR TITLE
Fix segfault

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -65,12 +65,12 @@ pub enum XMLFormatFlags {
 }
 
 const NFQ_XML_HW: u32 = 1;
-const NFQ_XML_MARK: u32 = (1 << 1);
-const NFQ_XML_DEV: u32 = (1 << 2);
-const NFQ_XML_PHYSDEV: u32 = (1 << 3);
-const NFQ_XML_PAYLOAD: u32 = (1 << 4);
-const NFQ_XML_TIME: u32 = (1 << 5);
-const NFQ_XML_ALL: u32 = (!0u32);
+const NFQ_XML_MARK: u32 = 1 << 1;
+const NFQ_XML_DEV: u32 = 1 << 2;
+const NFQ_XML_PHYSDEV: u32 = 1 << 3;
+const NFQ_XML_PAYLOAD: u32 = 1 << 4;
+const NFQ_XML_TIME: u32 = 1 << 5;
+const NFQ_XML_ALL: u32 = !0u32;
 
 /// Hardware address
 #[repr(C)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -118,7 +118,7 @@ extern "C" {
     fn nfq_get_physoutdev(nfad: NfqueueData) -> u32;
 
     fn nfq_get_packet_hw(nfad: NfqueueData) -> *const NfMsgPacketHw;
-    fn nfq_get_payload(nfad: NfqueueData, data: &*mut libc::c_void) -> libc::c_int;
+    fn nfq_get_payload(nfad: NfqueueData, data: &mut *mut libc::c_void) -> libc::c_int;
 
     // printing functions
     fn nfq_snprintf_xml(
@@ -301,11 +301,11 @@ impl Message {
     /// The actual amount and type of data retrieved by this function will
     /// depend on the mode set with the `set_mode()` function.
     pub fn get_payload(&self) -> &[u8] {
-        let c_ptr = std::ptr::null_mut();
-        let payload_len = unsafe { nfq_get_payload(self.nfad, &c_ptr) };
-        let payload: &[u8] =
-            unsafe { std::slice::from_raw_parts(c_ptr as *mut u8, payload_len as usize) };
-
+        let mut c_ptr = std::ptr::null_mut();
+        let payload_len = unsafe { nfq_get_payload(self.nfad, &mut c_ptr) };
+        let payload = unsafe {
+            std::slice::from_raw_parts(c_ptr as *mut _, payload_len as usize)
+        };
         payload
     }
 


### PR DESCRIPTION
Hi!
This PR fixes #15 

The problem is that `nfq_get_payload` takes a pointer of pointer in parameters in order to return a pointer of the received packet.
The original code uses `&*mut libc::c_void` to describe this. This is not correct as the *value* of the pointer will be modified by `nfq_get_payload`. The correct declaration may be `&mut *mut libc::c_void`.

This code crashed in release mode due to the optimization made:
- the pointer initialization is null
- a reference on this pointer is given to `nfq_get_payload`, but as it's given as `&`, it notes that the pointer value cannot be changed.
- when creating the slice from the pointer value, the optimization creates it using on a null pointer
- (this can be seen if you disassemble the binary)

